### PR TITLE
feat: add support for custom inference api

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
-OPENPIPE_API_KEY=<APIKEY>
-OPENPIPE_MODEL=openpipe:oncollama-v3-beta1
+API_KEY=<APIKEY>
+MODEL=openpipe:oncollama-v3-beta1
+BASE_URL=<BASEURL>

--- a/gui.py
+++ b/gui.py
@@ -10,6 +10,7 @@ class OpenPipeGUI:
     def __init__(self):
         self.api_key = None
         self.model = None
+        self.base_url = None
         self.connected = False
 
     def parse_escape_sequences(self, text):
@@ -26,7 +27,7 @@ class OpenPipeGUI:
         Initialise GUI, test API connection
         """
         # for api keys
-        self.api_key, self.model = load_env_vars()
+        self.api_key, self.model, self.base_url = load_env_vars()
 
         if not self.api_key or not self.model:
             dpg.set_value("status_text", "Error: Missing API key or model in .env")
@@ -34,7 +35,7 @@ class OpenPipeGUI:
             return
 
         dpg.set_value("status_text", "Testing connection...")
-        success, message = test_connection(self.api_key, self.model)
+        success, message = test_connection(self.api_key, self.model, self.base_url)
 
         self.connected = success
         dpg.set_value("status_text", message)
@@ -67,7 +68,7 @@ class OpenPipeGUI:
         dpg.configure_item("infer_button", enabled=False)
 
         # call API
-        success, result = call_openpipe_api(self.api_key, self.model, input_text)
+        success, result = call_openpipe_api(self.api_key, self.model, input_text, self.base_url)
 
         dpg.set_value("output_text", result)
         dpg.configure_item("infer_button", enabled=True)

--- a/utils.py
+++ b/utils.py
@@ -7,21 +7,21 @@ from oncollamaschemav3.prompt import create_system_prompt
 
 """
 utils.py - supporting functions for backend operations (API, data processing)
-
-Currently hard-coded to openpipe serverless deployment
-Can refactor for additional LLM client compatibility (e.g. Bedrock)
 """
 
 def load_env_vars():
     load_dotenv()
-    api_key = os.getenv("OPENPIPE_API_KEY")
-    model = os.getenv("OPENPIPE_MODEL")
-    return api_key, model
+    api_key = os.getenv("API_KEY")
+    model = os.getenv("MODEL")
+    base_url = os.getenv("BASE_URL", None)
+    return api_key, model, base_url
 
+def get_client(api_key, base_url=None):
+    return OpenAI(api_key=api_key, base_url=base_url) if base_url else OpenAI(api_key=api_key, openpipe={"api_key": api_key})
 
-def test_connection(api_key, model):
+def test_connection(api_key, model, base_url=None):
     try:
-        client = OpenAI(openpipe={"api_key": api_key})
+        client = get_client(api_key, base_url)
         client.chat.completions.create(
             model=model,
             messages=[{"role": "user", "content": "test"}],
@@ -50,9 +50,9 @@ def extract_output_json(text):
     return text  # or return original
 
 
-def call_openpipe_api(api_key, model, user_text):
+def call_openpipe_api(api_key, model, user_text, base_url=None):
     try:
-        client = OpenAI(openpipe={"api_key": api_key})
+        client = get_client(api_key, base_url)
         system_prompt = create_system_prompt('infer_prompt.txt')
 
         completion = client.chat.completions.create(


### PR DESCRIPTION
### Description

Adds support for generic OpenAI-based inference APIs, rather than being hard-coded to OpenPipe.

### Acceptance criteria

- [ ] Client can still connect to OpenPipe. In confirming this, double-check that double API key specification ([suggested by the docs](https://github.com/OpenPipe/OpenPipe?tab=readme-ov-file#using-locally)) is necessary: https://github.com/londonaicentre/oncollamatest/blob/75cd55eda038d637ec721de6586a8821e2902f12/utils.py#L20